### PR TITLE
Fix CVE-2026-29063: immutable prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.3",
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "immutable": "^5.1.5"
   }
 }


### PR DESCRIPTION
Add immutable ^5.1.5 override to ensure the patched version is used, addressing the high-severity prototype pollution in mergeDeep(), mergeDeepWith(), merge(), Map.toJS(), and Map.toObject() APIs.

https://claude.ai/code/session_01GxF3KNHRE6KPc636H89Lpp